### PR TITLE
Fesature/delete cover

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -121,3 +121,13 @@ function showSavedCovers() {
     </section>`
   }
 }
+
+function deleteCover() {
+  var clickedMiniCover = event.target.closest(".mini-cover");
+  for (var i = 0; i < savedCovers.length; i++) {
+    if (savedCovers[i].id === Number(clickedMiniCover.id)) {
+      savedCovers.splice(i, 1);
+    }
+  }
+  showSavedCovers();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -38,7 +38,7 @@ viewSavedCoverBtn.addEventListener('click', showSavedCoverView)
 homeBtn.addEventListener('click', showMainView)
 createCoverBtn.addEventListener('click', createNewCover)
 saveCoverBtn.addEventListener('click', saveCurrentCover)
-
+savedCoverSection.addEventListener('dblclick', deleteCover)
 ////// EVENT HANDLERS AND OTHER FUNCTIONS👇///////////
 
 function getRandomIndex(array) {


### PR DESCRIPTION
## 🚨🤦🏽🚨 *Problem:*
 <!-- what one thing are you doing? bug? refactor? feature? Please describe the problem you're trying to solve -->

- Feature on iteration5 , delete cover from saved cover section on double click, attaching event target to a mini cover. 

## 🌟💡🌟 *Solution:*
<!-- how are you solving this simply and elegantly? -->

- By using event delegation 

## 🤔💬🤔 *Test plan:*
<!-- what's your proof this works? unit tests? staging? If you want reviewer to click-test, include specific instructions -->

The proof is that we gave event listener to a parent element which is saved cover section and target to a closest element class name which is mini cover. So every time we click any cover id matching from id saved covers it would rove it on double click.

## 👁‍👁‍ *Changes:*
 <!-- what was the upfront planning that went into this? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
##  💠✅💠 *CheckList:* 
  <!-- Overview of your task  -->
- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
